### PR TITLE
doc: update phpdoc to allow mixed values

### DIFF
--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -9,7 +9,7 @@ interface Encrypter
      *
      * @param  mixed  $value
      * @param  bool  $serialize
-     * @return string
+     * @return mixed
      */
     public function encrypt($value, $serialize = true);
 
@@ -18,7 +18,7 @@ interface Encrypter
      *
      * @param  mixed  $payload
      * @param  bool  $unserialize
-     * @return string
+     * @return mixed
      */
     public function decrypt($payload, $unserialize = true);
 }

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -7,7 +7,7 @@ interface Encrypter
     /**
      * Encrypt the given value.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  bool  $serialize
      * @return string
      */
@@ -16,7 +16,7 @@ interface Encrypter
     /**
      * Decrypt the given value.
      *
-     * @param  string  $payload
+     * @param  mixed  $payload
      * @param  bool  $unserialize
      * @return string
      */


### PR DESCRIPTION
This updates the interface to match the parameters in Illuminate\Encryption\Encrypter which prevents the following message when using static analysis tools

```
Parameter #1 $value of method Illuminate\Contracts\Encryption\Encrypter::encrypt() expects string, array given.
```
